### PR TITLE
fix:issue logging bad access attempt

### DIFF
--- a/Database.py
+++ b/Database.py
@@ -304,7 +304,7 @@ class Database:
             logging.error(f"API error")
             details = {
                     "user_is_authorized": False,
-                    "card_type" : CardType(0),
+                    "card_type" : CardType(-1),
                     "user_authority_level": 0
                     }
         else:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Python 3.7+
 Software Libraries
 - Available as python modules
 	- configparser 
-	- mysql-connector
 	- RPi.GPIO
 	- spi 
 	- spidev
@@ -118,6 +117,6 @@ sudo systemctl enable portalbox.service
 - Email messages are hard coded in well code, templates should be used
 	- should be able to configure the location of email template files
 - GMail uses weak certificates which recent raspbian releases reject as invalid. We need to configure smtplib to ignore the weak certificates and use only the certificates raspbian find trustworthy (requires Python 3.x).
-- We use a custom spi, we should consider moving to spidev or releasing our versionverion of spi on PyPi.
+- We use a custom spi, we should consider moving to spidev or releasing our version of spi on PyPi.
 
 


### PR DESCRIPTION
In testing I found that presented with a card not authorized to access the portalbox, the portal box enters an infinite loop spiking webserver usage. This is the result of a trying to use a bad value for the CardType enumeration. This PR if accepted fixes the issue.